### PR TITLE
Centralize shared scripts, fix tools, and add license

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,37 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="The page you are looking for could not be found."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -70,78 +42,18 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank">
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-instagram"></i>
         </a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank">
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-snapchat"></i>
         </a>
-        <a href="https://github.com/yayloyanerik" target="_blank">
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>
         </a>
     </div>
 </footer>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Yayloyan.cc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -64,5 +64,11 @@ yayloyan.cc
 
 ### 👨‍💻 Made by Yayloyan
 
-Feedback, suggestions, or script ideas?  
+Feedback, suggestions, or script ideas?
 Feel free to [email me](mailto:info@yayloyan.cc) or open an issue.
+
+---
+
+## 📄 License
+
+This project is licensed under the [MIT License](LICENSE).

--- a/about/index.html
+++ b/about/index.html
@@ -8,39 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>
-        body {
-            opacity: 0;
-        }
-    </style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Learn about Yayloyan.cc and its mission to provide clean, powerful web tools."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -86,78 +56,18 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank">
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-instagram"></i>
         </a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank">
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-snapchat"></i>
         </a>
-        <a href="https://github.com/yayloyanerik" target="_blank">
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>
         </a>
     </div>
 </footer>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/encrypt/index.html
+++ b/encrypt/index.html
@@ -8,37 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Encrypt and decrypt text in your browser using AES-GCM and a password."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -74,38 +46,18 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank">
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-instagram"></i>
         </a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank">
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-snapchat"></i>
         </a>
-        <a href="https://github.com/yayloyanerik" target="_blank">
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>
         </a>
     </div>
 </footer>
-<script src="/encrypt.js"></script>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
+<script src="encrypt.js"></script>
 <div class="toast" id="toast">Copied to clipboard!</div>
 <script>
     function copyToClipboard(id) {
@@ -119,47 +71,7 @@
         });
     }
 </script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/hash/index.html
+++ b/hash/index.html
@@ -8,37 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Generate SHA-256, SHA-512, SHA-1, or MD5 hashes for files and text."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -85,40 +57,20 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank">
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-instagram"></i>
         </a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank">
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-snapchat"></i>
         </a>
-        <a href="https://github.com/yayloyanerik" target="_blank">
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>
         </a>
     </div>
 </footer>
 <!-- SparkMD5 for MD5 hashing -->
 <script src="https://cdnjs.cloudflare.com/ajax/libs/spark-md5/3.0.2/spark-md5.min.js"></script>
-<script src="/hash.js"></script>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
+<script src="hash.js"></script>
 <div class="toast" id="toast">Copied to clipboard!</div>
 <script>
     function copyToClipboard(id) {
@@ -132,59 +84,7 @@
         });
     }
 </script>
-<script>
-    function copyToClipboard(id) {
-        const el = document.getElementById(id);
-        if (!el || !el.innerText.trim()) return;
-        navigator.clipboard.writeText(el.innerText).then(() => {
-            const toast = document.getElementById("toast");
-            toast.textContent = "Copied to clipboard!";
-            toast.classList.add("show");
-            setTimeout(() => toast.classList.remove("show"), 2000);
-        });
-    }
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -12,39 +12,8 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-
-
-    <style>
-        body.fade-in {
-            animation: fadeIn 150ms ease-in forwards;
-        }
-
-        body.fade-out {
-            animation: fadeOut 150ms ease-out forwards;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -127,46 +96,11 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            const isInternalSection = href && (href.startsWith("#") || href.startsWith("/#"));
-            const isExternal = href && (href.startsWith("http") || anchor.target);
-            if (!isInternalSection && !isExternal) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 150);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 </html>

--- a/scripts/common.js
+++ b/scripts/common.js
@@ -1,0 +1,32 @@
+document.addEventListener('DOMContentLoaded', () => {
+    document.body.classList.add('fade-in');
+    const anchors = document.querySelectorAll('a[href]');
+    anchors.forEach(anchor => {
+        const href = anchor.getAttribute('href');
+        const isInternalSection = href && (href.startsWith('#') || href.startsWith('/#'));
+        const isExternal = href && (href.startsWith('http') || anchor.target);
+        if (!isInternalSection && !isExternal) {
+            anchor.addEventListener('click', e => {
+                e.preventDefault();
+                document.body.classList.remove('fade-in');
+                document.body.classList.add('fade-out');
+                setTimeout(() => {
+                    window.location = anchor.href;
+                }, 300);
+            });
+        }
+    });
+});
+
+const hamburger = document.getElementById('hamburger-menu');
+if (hamburger) {
+    const navbar = document.getElementById('navbar');
+    const hamburgerIcon = document.getElementById('hamburger-icon');
+    const closeIcon = document.getElementById('close-icon');
+    hamburger.addEventListener('click', () => {
+        navbar.classList.toggle('open');
+        const isOpen = navbar.classList.contains('open');
+        if (hamburgerIcon) hamburgerIcon.style.display = isOpen ? 'none' : 'block';
+        if (closeIcon) closeIcon.style.display = isOpen ? 'block' : 'none';
+    });
+}

--- a/scripts/index.html
+++ b/scripts/index.html
@@ -6,52 +6,28 @@
     <title>Script Hub – Yayloyan.cc</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Browse a curated collection of Bash, PowerShell, Git, and productivity scripts."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
     <div class="logo">
         <a href="/">Yayloyan</a>
     </div>
-    <nav>
+    <nav id="navbar">
         <ul>
             <li><a href="../#tools">Tools</a></li>
             <li><a href="../#projects">Projects</a></li>
             <li><a href="../#contact">Contact</a></li>
         </ul>
     </nav>
+    <div class="hamburger" id="hamburger-menu">
+        <i class="fas fa-bars" id="hamburger-icon"></i>
+        <i class="fas fa-times" id="close-icon"></i>
+    </div>
 </header>
 <section class="section">
     <h2>Script Hub</h2>
@@ -116,65 +92,18 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank">
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-instagram"></i>
         </a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank">
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-snapchat"></i>
         </a>
-        <a href="https://github.com/yayloyanerik" target="_blank">
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer">
             <i class="fab fa-github"></i>
         </a>
     </div>
 </footer>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/style.css
+++ b/style.css
@@ -349,14 +349,3 @@ textarea {
     }
 }
 
-/* Smooth page transition */
-body {
-    opacity: 0;
-    transform: translateY(10px);
-    transition: opacity 0.4s ease, transform 0.4s ease;
-}
-
-body.fade-in {
-    opacity: 1;
-    transform: translateY(0);
-}

--- a/styles/animations.css
+++ b/styles/animations.css
@@ -1,0 +1,21 @@
+body {
+    opacity: 0;
+}
+
+body.fade-in {
+    animation: fadeIn 0.3s ease-in forwards;
+}
+
+body.fade-out {
+    animation: fadeOut 0.3s ease-out forwards;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; }
+    to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+    from { opacity: 1; }
+    to { opacity: 0; }
+}

--- a/tools/base64/index.html
+++ b/tools/base64/index.html
@@ -8,37 +8,9 @@
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Encode and decode text with a Unicode-aware Base64 tool."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -70,21 +42,26 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
     function encode() {
         const input = document.getElementById('b64input').value;
-        document.getElementById('b64result').innerText = btoa(input);
+        const bytes = new TextEncoder().encode(input);
+        const binary = String.fromCharCode(...bytes);
+        document.getElementById('b64result').innerText = btoa(binary);
     }
 
     function decode() {
         const input = document.getElementById('b64input').value;
         try {
-            document.getElementById('b64result').innerText = atob(input);
+            const binary = atob(input);
+            const bytes = Uint8Array.from(binary, c => c.charCodeAt(0));
+            const decoded = new TextDecoder().decode(bytes);
+            document.getElementById('b64result').innerText = decoded;
         } catch {
             document.getElementById('b64result').innerText = "Invalid Base64 string.";
         }
@@ -107,67 +84,7 @@
         }, 2000);
     }
 </script>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/html-entities/index.html
+++ b/tools/html-entities/index.html
@@ -6,39 +6,11 @@
     <title>HTML Entities Converter</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Convert text to HTML entities and back with this simple tool."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -69,9 +41,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -100,67 +72,7 @@
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
 </script>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/json/index.html
+++ b/tools/json/index.html
@@ -6,39 +6,11 @@
     <title>JSON Formatter</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Format and minify JSON directly in your browser."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -68,9 +40,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -97,67 +69,8 @@
         toast.classList.add("show");
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
-
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
 </script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/password/index.html
+++ b/tools/password/index.html
@@ -6,39 +6,11 @@
     <title>Password Generator</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Generate secure passwords with customizable options."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -73,9 +45,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -117,67 +89,8 @@
         toast.classList.add("show");
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
-
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
 </script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/qr/index.html
+++ b/tools/qr/index.html
@@ -6,41 +6,13 @@
     <title>QR, Barcode &amp; Data Matrix Generator</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
     <script src="https://cdn.jsdelivr.net/npm/qrcode/build/qrcode.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/bwip-js/dist/bwip-js-min.js"></script>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Create QR codes, barcodes, and Data Matrix codes online."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -81,9 +53,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -146,66 +118,14 @@
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
 
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
+    function showToast(message) {
+        const toast = document.getElementById('toast');
+        toast.innerText = message;
+        toast.classList.add('show');
+        setTimeout(() => toast.classList.remove('show'), 2000);
+    }
 </script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/regex/index.html
+++ b/tools/regex/index.html
@@ -9,36 +9,8 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <link href="/styles/animations.css" rel="stylesheet"/>
+    <meta name="description" content="Test and debug regular expressions in real time."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -69,9 +41,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -104,67 +76,7 @@
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
 </script>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/text-counter/index.html
+++ b/tools/text-counter/index.html
@@ -9,36 +9,8 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <link href="/styles/animations.css" rel="stylesheet"/>
+    <meta name="description" content="Count characters, words, lines, and spaces in your text."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -74,75 +46,15 @@
             `Characters: ${chars}\nWords: ${words}\nLines: ${lines}\nBlank spaces: ${blanks}`;
     }
 </script>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/timestamp/index.html
+++ b/tools/timestamp/index.html
@@ -6,39 +6,11 @@
     <title>Timestamp Converter</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Convert Unix timestamps to readable dates and back."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -73,9 +45,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -111,67 +83,8 @@
         toast.classList.add("show");
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
-
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
 </script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/url-encoder/index.html
+++ b/tools/url-encoder/index.html
@@ -6,39 +6,11 @@
     <title>URL Encoder / Decoder</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
+    <meta name="description" content="Encode or decode URLs with this safe online tool."/>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -69,9 +41,9 @@
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
 <script>
@@ -97,67 +69,8 @@
         toast.classList.add("show");
         setTimeout(() => toast.classList.remove("show"), 2000);
     }
-
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
 </script>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>

--- a/tools/uuid/index.html
+++ b/tools/uuid/index.html
@@ -6,9 +6,11 @@
     <title>UUID Generator</title>
     <meta content="width=device-width, initial-scale=1.0" name="viewport"/>
     <link href="/style.css" rel="stylesheet"/>
+    <link href="/styles/animations.css" rel="stylesheet"/>
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@600&amp;family=Rubik&amp;display=swap"
           rel="stylesheet"/>
+    <meta name="description" content="Generate UUIDs (v1, v4, v5) with optional names and bulk support."/>
     <script type="module">
         import {NIL as uuidNil, v1 as uuidv1, v4 as uuidv4, v5 as uuidv5} from 'https://esm.sh/uuid';
 
@@ -63,36 +65,6 @@
             setTimeout(() => toast.classList.remove("show"), 2000);
         };
     </script>
-    <style>body {
-        opacity: 0;
-    }</style>
-    <style>
-        body.fade-in {
-            animation: fadeIn 0.3s ease-in;
-        }
-
-        body.fade-out {
-            animation: fadeOut 0.3s ease-out;
-        }
-
-        @keyframes fadeIn {
-            from {
-                opacity: 0;
-            }
-            to {
-                opacity: 1;
-            }
-        }
-
-        @keyframes fadeOut {
-            from {
-                opacity: 1;
-            }
-            to {
-                opacity: 0;
-            }
-        }
-    </style>
 </head>
 <body class="fade-in">
 <header class="navbar">
@@ -135,75 +107,15 @@
     </section>
     <div class="toast" id="toast">Copied to clipboard!</div>
 </main>
-<script>
-    const hamburger = document.getElementById('hamburger-menu');
-    const navbar = document.getElementById('navbar');
-    const hamburgerIcon = document.getElementById('hamburger-icon');
-    const closeIcon = document.getElementById('close-icon');
-
-    hamburger.addEventListener('click', () => {
-        navbar.classList.toggle('open');
-        const isOpen = navbar.classList.contains('open');
-        hamburgerIcon.style.display = isOpen ? 'none' : 'block';
-        closeIcon.style.display = isOpen ? 'block' : 'none';
-    });
-</script>
 <footer class="footer">
     <p>© 2025 Yayloyan.cc — All rights reserved</p>
     <div class="social-links">
-        <a href="https://instagram.com/er313__" target="_blank"><i class="fab fa-instagram"></i></a>
-        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank"><i class="fab fa-snapchat"></i></a>
-        <a href="https://github.com/yayloyanerik" target="_blank"><i class="fab fa-github"></i></a>
+        <a href="https://instagram.com/er313__" target="_blank" rel="noopener noreferrer"><i class="fab fa-instagram"></i></a>
+        <a href="https://snapchat.com/add/e_yayloyan313" target="_blank" rel="noopener noreferrer"><i class="fab fa-snapchat"></i></a>
+        <a href="https://github.com/yayloyanerik" target="_blank" rel="noopener noreferrer"><i class="fab fa-github"></i></a>
     </div>
 </footer>
-<script>
-    window.addEventListener("load", () => {
-        requestAnimationFrame(() => {
-            document.body.classList.add("fade-in");
-        });
-    });
-</script>
-<script>
-    document.querySelectorAll("a[href^='/']:not([target])").forEach(link => {
-        link.addEventListener("click", function (e) {
-            if (e.metaKey || e.ctrlKey) return;
-            if (link.getAttribute("href").startsWith("#")) return;
-            e.preventDefault();
-            document.body.classList.remove("fade-in");
-            document.body.style.opacity = 0;
-            setTimeout(() => {
-                window.location.href = link.href;
-            }, 300);
-        });
-    });
-</script>
-
-<script>
-    document.addEventListener("DOMContentLoaded", function () {
-        document.body.classList.add("fade-in");
-        const anchors = document.querySelectorAll("a[href]");
-        anchors.forEach(anchor => {
-            const href = anchor.getAttribute("href");
-            if (
-                href &&
-                !href.startsWith("http") &&
-                !href.startsWith("#") &&
-                !href.startsWith("/#") &&
-                !anchor.target &&
-                !href.includes(".pdf")
-            ) {
-                anchor.addEventListener("click", function (e) {
-                    e.preventDefault();
-                    document.body.classList.remove("fade-in");
-                    document.body.classList.add("fade-out");
-                    setTimeout(() => {
-                        window.location = anchor.href;
-                    }, 300);
-                });
-            }
-        });
-    });
-</script>
+<script src="/scripts/common.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- centralize fade effects and navigation into reusable `styles/animations.css` and `scripts/common.js`
- support Unicode in Base64 tool and clean up Hash/Encrypt scripts
- add MIT LICENSE and reference it in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bbd6319aa8832495a7b7bd4512622a